### PR TITLE
Create AI platform monorepo skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.DS_Store
+/dist
+/apps/*/dist
+/packages/*/dist
+**/__pycache__

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# enterprise-repo
+# Enterprise Monorepo
+
+This repository provides a boilerplate for a scalable AI‑native application platform. It uses **Turborepo** to manage polyglot microservices and shared packages.
+
+## Structure
+
+- **apps/** – web, mobile and backend services
+- **genai-agents/** – multi‑agent orchestration
+- **vector-stores/** – vector databases and embeddings
+- **data-platform/** – lakehouse and analytics
+- **sap-integration/** – SAP connectivity helpers
+- **packages/** – reusable libraries
+- **infra/** – infrastructure as code
+- **tests/** – end‑to‑end tests
+
+Each service is intentionally minimal. Extend the modules as needed for your organisation.

--- a/apps/backend-go/go.mod
+++ b/apps/backend-go/go.mod
@@ -1,0 +1,5 @@
+module backend-go
+
+go 1.20
+
+require github.com/gin-gonic/gin v1.9.1

--- a/apps/backend-go/main.go
+++ b/apps/backend-go/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+    r := gin.Default()
+    r.GET("/", func(c *gin.Context) {
+        c.JSON(200, gin.H{"message": "Hello from Gin"})
+    })
+    r.Run(":3003")
+}

--- a/apps/backend-nest/package.json
+++ b/apps/backend-nest/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend-nest",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "bun run src/main.ts",
+    "build": "bun build src/main.ts --outdir dist"
+  },
+  "dependencies": {
+    "@nestjs/common": "10.1.3",
+    "@nestjs/core": "10.1.3",
+    "reflect-metadata": "^0.1.13"
+  }
+}

--- a/apps/backend-nest/src/main.ts
+++ b/apps/backend-nest/src/main.ts
@@ -1,0 +1,20 @@
+import { NestFactory } from '@nestjs/core';
+import { Module, Controller, Get } from '@nestjs/common';
+
+@Controller()
+class AppController {
+  @Get()
+  getRoot() {
+    return { message: 'Hello from Nest' };
+  }
+}
+
+@Module({ controllers: [AppController] })
+class AppModule {}
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+
+bootstrap();

--- a/apps/backend-python/app/main.py
+++ b/apps/backend-python/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello from FastAPI"}

--- a/apps/backend-python/main.py
+++ b/apps/backend-python/main.py
@@ -1,0 +1,5 @@
+from app.main import app
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=3004)

--- a/apps/backend-python/requirements.txt
+++ b/apps/backend-python/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.110.0
+uvicorn==0.27.0

--- a/apps/backend-rust/Cargo.toml
+++ b/apps/backend-rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "backend_rust"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4"

--- a/apps/backend-rust/src/main.rs
+++ b/apps/backend-rust/src/main.rs
@@ -1,0 +1,14 @@
+use actix_web::{get, App, HttpResponse, HttpServer, Responder};
+
+#[get("/")]
+async fn index() -> impl Responder {
+    HttpResponse::Ok().json("Hello from Actix")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| App::new().service(index))
+        .bind(("0.0.0.0", 3002))?
+        .run()
+        .await
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: Center(child: Text('Enterprise Mobile App')),
+      ),
+    );
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -1,0 +1,12 @@
+name: enterprise_mobile
+publish_to: 'none'
+version: 0.1.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Welcome to the Enterprise Platform</h1>
+    </main>
+  );
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.8",
+    "@types/node": "20.4.5",
+    "tailwindcss": "^3.3.3"
+  }
+}

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: [require('daisyui')]
+};

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "module": "esnext",
+    "target": "es2017",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/data-platform/README.md
+++ b/data-platform/README.md
@@ -1,0 +1,3 @@
+# Data Platform
+
+This module contains dbt models, ClickHouse schemas and dashboard configurations.

--- a/genai-agents/README.md
+++ b/genai-agents/README.md
@@ -1,0 +1,3 @@
+# GenAI Agents
+
+This folder contains sample integrations with LangChain, LlamaIndex and other frameworks. Use these modules to orchestrate multi-agent workflows and connect to external services like SAP or vector stores.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,3 @@
+# Infrastructure
+
+Terraform configurations and Dockerfiles for deploying services and supporting infrastructure.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "enterprise-monorepo",
+  "private": true,
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo run test"
+  },
+  "devDependencies": {
+    "turbo": "^1.11.3"
+  }
+}

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@enterprise/realtime",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@fluidframework/server-lambdas": "2.1.3"
+  }
+}

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -1,0 +1,3 @@
+export function setupRealtime() {
+  console.log('Initialize Fluid Framework');
+}

--- a/packages/realtime/tsconfig.json
+++ b/packages/realtime/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@enterprise/utils",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {}
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,0 +1,3 @@
+export function greet(name: string) {
+  return `Hello, ${name}`;
+}

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/sap-integration/README.md
+++ b/sap-integration/README.md
@@ -1,0 +1,3 @@
+# SAP Integration
+
+Utilities for connecting to SAP systems using Cloud Connector and BTP Destination Service.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,3 @@
+# Tests
+
+End-to-end tests using Playwright.

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  webServer: {
+    command: 'pnpm --filter web dev',
+    port: 3000,
+    reuseExistingServer: true
+  },
+  testDir: './playwright'
+});

--- a/tests/playwright/example.spec.ts
+++ b/tests/playwright/example.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('homepage has welcome text', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page.locator('h1')).toHaveText('Welcome to the Enterprise Platform');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": ["node_modules"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "build/**"]
+    },
+    "dev": {
+      "cache": false
+    },
+    "lint": {},
+    "test": {}
+  }
+}

--- a/vector-stores/README.md
+++ b/vector-stores/README.md
@@ -1,0 +1,3 @@
+# Vector Stores
+
+Configuration and scripts for MongoDB Atlas Vector Search and S3-based embedding storage.


### PR DESCRIPTION
## Summary
- scaffold turborepo workspace with Next.js webapp, Flutter mobile app and polyglot microservices
- add utils and realtime packages
- add minimal infra, SAP integration and data platform folders
- provide Playwright test scaffolding

## Testing
- `npx playwright --version`
- `npx playwright test tests/playwright/example.spec.ts --reporter=list --pass-with-no-tests` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_6879bca8b338832db46b58c21e66b12b