### PR TITLE
Add GenAI orchestrators and multi-agent modules

### DIFF
--- a/a2a-protocol/README.md
+++ b/a2a-protocol/README.md
@@ -1,0 +1,3 @@
+# A2A Protocol
+
+Utilities for passing messages directly between agents. Messages are stored in a simple in-memory inbox.

--- a/a2a-protocol/__init__.py
+++ b/a2a-protocol/__init__.py
@@ -1,0 +1,5 @@
+"""Agent-to-Agent communication primitives."""
+
+from .protocol import Message, send_message
+
+__all__ = ["Message", "send_message"]

--- a/a2a-protocol/protocol.py
+++ b/a2a-protocol/protocol.py
@@ -1,0 +1,29 @@
+"""Simple in-memory message passing between agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List
+
+
+@dataclass
+class Message:
+    sender: str
+    receiver: str
+    content: Any
+
+
+_inbox: List[Message] = []
+
+
+def send_message(msg: Message) -> None:
+    """Place a message in the global inbox."""
+    _inbox.append(msg)
+
+
+def receive_messages(receiver: str) -> list[Message]:
+    """Retrieve and clear messages for a receiver."""
+    received = [m for m in _inbox if m.receiver == receiver]
+    for m in received:
+        _inbox.remove(m)
+    return received

--- a/genai-agents/README.md
+++ b/genai-agents/README.md
@@ -1,3 +1,10 @@
 # GenAI Agents
 
-This folder contains sample integrations with LangChain, LlamaIndex and other frameworks. Use these modules to orchestrate multi-agent workflows and connect to external services like SAP or vector stores.
+This folder contains orchestrators for various generative AI frameworks. Each agent exposes a standard `run(task: AgentTask)` interface.
+
+- **LangChainBedrockAgent** – LangChain agent running on AWS Bedrock
+- **CrewAgent** – role and task decomposition with CrewAI
+- **AutoGenOrchestrator** – multi-agent dialogue using AutoGen
+- **LlamaIndexAgent** – context-aware retrieval augmented generation
+- **LlamaGraphAgent** – knowledge graph querying via LlamaGraph
+- **StrandsRoutingAgent** – graph-routed decision making

--- a/genai-agents/__init__.py
+++ b/genai-agents/__init__.py
@@ -1,0 +1,19 @@
+"""Collection of GenAI agent orchestrators."""
+
+from .agent_task import AgentTask
+from .langchain_bedrock_agent import LangChainBedrockAgent
+from .crew_agent import CrewAgent
+from .autogen_agent import AutoGenOrchestrator
+from .llamaindex_agent import LlamaIndexAgent
+from .llamagraph_agent import LlamaGraphAgent
+from .strands_agent import StrandsRoutingAgent
+
+__all__ = [
+    "AgentTask",
+    "LangChainBedrockAgent",
+    "CrewAgent",
+    "AutoGenOrchestrator",
+    "LlamaIndexAgent",
+    "LlamaGraphAgent",
+    "StrandsRoutingAgent",
+]

--- a/genai-agents/agent_task.py
+++ b/genai-agents/agent_task.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class AgentTask:
+    """Simple container for a task given to an agent."""
+
+    description: str
+    context: Dict[str, Any] | None = None

--- a/genai-agents/autogen_agent.py
+++ b/genai-agents/autogen_agent.py
@@ -1,0 +1,23 @@
+"""AutoGen multi-agent dialogue orchestrator."""
+
+from __future__ import annotations
+
+from autogen.agentchat import Agent
+
+from .agent_task import AgentTask
+
+
+class AutoGenOrchestrator:
+    """Orchestrates a dialogue between agents using AutoGen."""
+
+    def __init__(self, agents: list[Agent] | None = None) -> None:
+        self.agents = agents or []
+
+    def run(self, task: AgentTask) -> str:
+        """Start a dialogue using the provided agents and return the final output."""
+        if not self.agents:
+            return "No agents configured"
+        message = task.description
+        for agent in self.agents:
+            message = agent.generate_reply(message)
+        return message

--- a/genai-agents/crew_agent.py
+++ b/genai-agents/crew_agent.py
@@ -1,0 +1,21 @@
+"""CrewAI based task decomposition."""
+
+from __future__ import annotations
+
+from crewai import Crew, Task
+
+from .agent_task import AgentTask
+
+
+class CrewAgent:
+    """Uses CrewAI to break down tasks by role."""
+
+    def __init__(self, role: str = "assistant") -> None:
+        self.role = role
+
+    def run(self, task: AgentTask) -> str:
+        """Decompose the task using CrewAI and return combined result."""
+        crew = Crew(role=self.role)
+        crew_task = Task(description=task.description, context=task.context or {})
+        result = crew.execute([crew_task])
+        return result

--- a/genai-agents/langchain_bedrock_agent.py
+++ b/genai-agents/langchain_bedrock_agent.py
@@ -1,0 +1,21 @@
+"""LangChain agent running on AWS Bedrock."""
+
+from __future__ import annotations
+
+from langchain.chat_models import BedrockChat
+from langchain.schema import SystemMessage
+
+from .agent_task import AgentTask
+
+
+class LangChainBedrockAgent:
+    """Wrapper around a LangChain agent using Bedrock."""
+
+    def __init__(self, model_id: str = "anthropic.claude-v2") -> None:
+        self.llm = BedrockChat(model_id=model_id)
+
+    def run(self, task: AgentTask) -> str:
+        """Execute the agent task using Bedrock and return the response text."""
+        messages = [SystemMessage(content=task.description)]
+        resp = self.llm(messages)
+        return resp.content

--- a/genai-agents/llamagraph_agent.py
+++ b/genai-agents/llamagraph_agent.py
@@ -1,0 +1,19 @@
+"""Knowledge graph integration using LlamaGraph."""
+
+from __future__ import annotations
+
+from llamagraph import Graph
+
+from .agent_task import AgentTask
+
+
+class LlamaGraphAgent:
+    """Queries a knowledge graph via LlamaGraph."""
+
+    def __init__(self, uri: str) -> None:
+        self.graph = Graph(uri)
+
+    def run(self, task: AgentTask) -> str:
+        """Run a graph query based on the task description."""
+        result = self.graph.query(task.description)
+        return str(result)

--- a/genai-agents/llamaindex_agent.py
+++ b/genai-agents/llamaindex_agent.py
@@ -1,0 +1,21 @@
+"""Context aware retrieval using LlamaIndex."""
+
+from __future__ import annotations
+
+from llama_index import VectorStoreIndex, SimpleDirectoryReader
+
+from .agent_task import AgentTask
+
+
+class LlamaIndexAgent:
+    """Uses LlamaIndex to provide RAG functionality."""
+
+    def __init__(self, data_path: str) -> None:
+        documents = SimpleDirectoryReader(data_path).load_data()
+        self.index = VectorStoreIndex.from_documents(documents)
+        self.query_engine = self.index.as_query_engine()
+
+    def run(self, task: AgentTask) -> str:
+        """Query the index with the task description."""
+        response = self.query_engine.query(task.description)
+        return str(response)

--- a/genai-agents/strands_agent.py
+++ b/genai-agents/strands_agent.py
@@ -1,0 +1,19 @@
+"""Decision making via Strands Agents."""
+
+from __future__ import annotations
+
+from strands_agents import StrandsEngine
+
+from .agent_task import AgentTask
+
+
+class StrandsRoutingAgent:
+    """Route decisions through a Strands graph."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.engine = StrandsEngine(config or {})
+
+    def run(self, task: AgentTask) -> str:
+        """Execute decision making with graph routing."""
+        result = self.engine.route(task.description, task.context or {})
+        return str(result)

--- a/mcp-controller/README.md
+++ b/mcp-controller/README.md
@@ -1,0 +1,3 @@
+# MCP Controller
+
+A lightweight control plane that dispatches `AgentTask` instances to multiple agents and aggregates the results.

--- a/mcp-controller/__init__.py
+++ b/mcp-controller/__init__.py
@@ -1,0 +1,5 @@
+"""Multi-Agent Control Plane."""
+
+from .controller import MultiAgentController
+
+__all__ = ["MultiAgentController"]

--- a/mcp-controller/controller.py
+++ b/mcp-controller/controller.py
@@ -1,0 +1,22 @@
+"""Simple control plane to orchestrate agents."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from genai_agents import AgentTask
+
+
+class MultiAgentController:
+    """Dispatch tasks to multiple agents and gather results."""
+
+    def __init__(self, agents: Iterable) -> None:
+        self.agents = list(agents)
+
+    def run(self, task: AgentTask) -> list[str]:
+        """Run the task across all registered agents."""
+        results = []
+        for agent in self.agents:
+            if hasattr(agent, "run"):
+                results.append(agent.run(task))
+        return results


### PR DESCRIPTION
## Summary
- add LangChain, CrewAI, AutoGen, LlamaIndex, LlamaGraph and Strands Agents orchestrators
- implement a simple control plane for orchestrating agents
- provide an agent-to-agent protocol for message passing
- document the new modules in READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879c24266d4832d83bfc88f43f0a157