### PR TITLE
Add Prisma client package and schemas

### DIFF
--- a/apps/fastapi-report-engine/prisma/schema.prisma
+++ b/apps/fastapi-report-engine/prisma/schema.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int        @id @default(autoincrement())
+  email     String     @unique
+  name      String?
+  orders    SAPOrder[]
+}
+
+model SAPOrder {
+  id          Int      @id @default(autoincrement())
+  orderNumber String
+  userId      Int?
+  user        User?     @relation(fields: [userId], references: [id])
+  createdAt   DateTime @default(now())
+}

--- a/apps/nest-core-api/prisma/schema.prisma
+++ b/apps/nest-core-api/prisma/schema.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int        @id @default(autoincrement())
+  email     String     @unique
+  name      String?
+  orders    SAPOrder[]
+}
+
+model SAPOrder {
+  id          Int      @id @default(autoincrement())
+  orderNumber String
+  userId      Int?
+  user        User?     @relation(fields: [userId], references: [id])
+  createdAt   DateTime @default(now())
+}

--- a/packages/prisma-client/package.json
+++ b/packages/prisma-client/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@enterprise/prisma-client",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "generate": "prisma generate --schema=./prisma/schema.prisma",
+    "seed": "node dist/seed.js"
+  },
+  "dependencies": {
+    "@prisma/client": "5.14.0"
+  },
+  "devDependencies": {
+    "prisma": "5.14.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/prisma-client/prisma/schema.prisma
+++ b/packages/prisma-client/prisma/schema.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int        @id @default(autoincrement())
+  email     String     @unique
+  name      String?
+  orders    SAPOrder[]
+}
+
+model SAPOrder {
+  id          Int      @id @default(autoincrement())
+  orderNumber String
+  userId      Int?
+  user        User?     @relation(fields: [userId], references: [id])
+  createdAt   DateTime @default(now())
+}

--- a/packages/prisma-client/src/index.ts
+++ b/packages/prisma-client/src/index.ts
@@ -1,0 +1,6 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export { PrismaClient } from '@prisma/client';
+export default prisma;

--- a/packages/prisma-client/src/seed.ts
+++ b/packages/prisma-client/src/seed.ts
@@ -1,0 +1,24 @@
+import prisma from './index';
+
+async function main() {
+  await prisma.user.create({
+    data: {
+      email: 'alice@example.com',
+      name: 'Alice',
+      orders: {
+        create: {
+          orderNumber: 'SO-1'
+        }
+      }
+    }
+  });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/prisma-client/tsconfig.json
+++ b/packages/prisma-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add Prisma schema for Nest API
- add Prisma schema for FastAPI engine
- create shared `prisma-client` package with Prisma setup
- seed sample `User` and `SAPOrder` models

## Testing
- `npm run build` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c6d0639c832d9ea1ea2b7fcab5de