### PR TITLE
Add Flutter mobile PWA skeleton

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,18 @@
+# Enterprise Mobile App
+
+This Flutter project targets Web, Android, and iOS. Platform folders were not
+checked into version control. Run the following command to create them:
+
+```bash
+flutter create . --platforms=android,ios,web
+```
+
+Afterwards you can build the web app with PWA support:
+
+```bash
+flutter build web
+```
+
+The `web/` directory already contains a service worker (`pwabuilder-sw.js`) and
+manifest generated via PWABuilder. The service worker is registered in
+`web/index.html`. Icon URLs are placeholders pointing to `via.placeholder.com`.

--- a/apps/mobile/lib/api/api_client.dart
+++ b/apps/mobile/lib/api/api_client.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class ApiClient {
+  final String baseUrl;
+  const ApiClient(this.baseUrl);
+
+  Future<http.Response> get(String path) {
+    final uri = Uri.parse('$baseUrl$path');
+    return http.get(uri);
+  }
+
+  Future<http.Response> post(String path, Map<String, dynamic> data) {
+    final uri = Uri.parse('$baseUrl$path');
+    return http.post(uri, body: jsonEncode(data), headers: {'Content-Type': 'application/json'});
+  }
+}

--- a/apps/mobile/lib/main.dart
+++ b/apps/mobile/lib/main.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'api/api_client.dart';
+import 'pages/home_page.dart';
+import 'pages/agent_dashboard_page.dart';
+import 'pages/sap_summary_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -9,10 +13,16 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: Scaffold(
-        body: Center(child: Text('Enterprise Mobile App')),
-      ),
+    final apiClient = ApiClient('https://api.example.com');
+
+    return MaterialApp(
+      title: 'Enterprise Mobile',
+      routes: {
+        '/': (context) => const HomePage(),
+        '/dashboard': (context) => const AgentDashboardPage(),
+        '/sap-summary': (context) => const SapSummaryPage(),
+      },
+      initialRoute: '/',
     );
   }
 }

--- a/apps/mobile/lib/pages/agent_dashboard_page.dart
+++ b/apps/mobile/lib/pages/agent_dashboard_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AgentDashboardPage extends StatelessWidget {
+  const AgentDashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Agent Dashboard')),
+      body: const Center(child: Text('Agent stats and controls go here.')),
+    );
+  }
+}

--- a/apps/mobile/lib/pages/home_page.dart
+++ b/apps/mobile/lib/pages/home_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: const Center(child: Text('Welcome to Enterprise Mobile')),
+    );
+  }
+}

--- a/apps/mobile/lib/pages/sap_summary_page.dart
+++ b/apps/mobile/lib/pages/sap_summary_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class SapSummaryPage extends StatelessWidget {
+  const SapSummaryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('SAP Summary')),
+      body: const Center(child: Text('High level SAP metrics here.')),
+    );
+  }
+}

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  http: ^0.13.5
 
 flutter:
   uses-material-design: true

--- a/apps/mobile/web/index.html
+++ b/apps/mobile/web/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#000000">
+    <link rel="manifest" href="manifest.json">
+    <title>Enterprise Mobile</title>
+  </head>
+  <body>
+    <script src="main.dart.js" type="application/javascript"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('pwabuilder-sw.js');
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/apps/mobile/web/manifest.json
+++ b/apps/mobile/web/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Enterprise Mobile",
+  "short_name": "Enterprise",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "https://via.placeholder.com/192",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://via.placeholder.com/512",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/apps/mobile/web/pwabuilder-sw.js
+++ b/apps/mobile/web/pwabuilder-sw.js
@@ -1,0 +1,17 @@
+self.addEventListener('install', event => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.open('offline').then(cache => {
+      return cache.match(event.request).then(response => {
+        return response || fetch(event.request);
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- set up Flutter app structure in `apps/mobile`
- add Home, Agent Dashboard and SAP Summary pages
- add basic API client
- scaffold web folder with PWABuilder service worker and manifest
- document how to add platform folders for Android and iOS
- register the service worker and remove binary icons

## Testing
- `npm test` *(fails: nx not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879c9e29364832d880d70430dc63540