### PR TITLE
Add DesignOps workflow with Storybook and Lost Pixel

### DIFF
--- a/.github/workflows/designops.yml
+++ b/.github/workflows/designops.yml
@@ -1,0 +1,46 @@
+name: DesignOps
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/*'
+    paths:
+      - 'packages/shared-ui/**'
+      - 'apps/frontend/**'
+      - 'apps/mobile/**'
+  workflow_dispatch:
+
+jobs:
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack enable
+      - run: pnpm install
+      - run: pnpm build-storybook
+      - uses: actions/upload-artifact@v3
+        with:
+          name: storybook-static
+          path: storybook-static
+
+  lostpixel:
+    needs: build-storybook
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack enable
+      - run: pnpm install
+      - uses: actions/download-artifact@v3
+        with:
+          name: storybook-static
+          path: storybook-static
+      - run: pnpm lostpixel

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Each service is intentionally minimal. Extend the modules as needed for your org
 - Elasticache for Redis is provisioned via Terraform and acts as the coordination layer for pub/sub.
 - The `@enterprise/realtime` package uses Fluid Framework to sync data in real time across the Next.js frontend and Flutter mobile app.
 - Example usage is provided as a shared task list where updates are stored in Redis along with agent state, chat context and collaborative docs.
+
+## DesignOps
+
+- Storybook renders UI components from `packages/shared-ui` with accessibility checks and docs.
+- Lost Pixel runs visual regression tests on Storybook to catch unintended UI changes.
+- GitHub Actions builds Storybook and executes Lost Pixel on pull requests targeting `main` or `release/*`.

--- a/lostpixel.config.ts
+++ b/lostpixel.config.ts
@@ -1,0 +1,11 @@
+import type { CustomProjectConfig } from 'lost-pixel';
+
+export const config: CustomProjectConfig = {
+  storybookShots: {
+    storybookUrl: './storybook-static',
+    breakpoints: [375, 768, 1024]
+  },
+  generateOnly: false,
+  failOnDifference: true
+};
+export default config;

--- a/package.json
+++ b/package.json
@@ -9,10 +9,19 @@
     "dev": "nx run-many --target=dev --parallel",
     "build": "nx run-many --target=build",
     "lint": "nx run-many --target=lint",
-    "test": "nx run-many --target=test"
+    "test": "nx run-many --target=test",
+    "storybook": "storybook dev -p 6006 -c storybook",
+    "build-storybook": "storybook build -c storybook -o storybook-static",
+    "lostpixel": "lost-pixel"
   },
   "devDependencies": {
     "nx": "^21.2.4",
-    "@playwright/test": "^1.42.1"
+    "@playwright/test": "^1.42.1",
+    "@storybook/nextjs": "^9.0.17",
+    "@storybook/addon-a11y": "^9.0.17",
+    "@storybook/addon-docs": "^9.0.17",
+    "@storybook/addon-controls": "^9.0.8",
+    "@storybook/cli": "^9.0.17",
+    "lost-pixel": "^3.22.0"
   }
 }

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@enterprise/shared-ui",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "react": "^18.2.0"
+  }
+}

--- a/packages/shared-ui/src/AgentConsole.stories.tsx
+++ b/packages/shared-ui/src/AgentConsole.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AgentConsole } from './AgentConsole';
+
+const meta: Meta<typeof AgentConsole> = {
+  title: 'Organisms/Agent Console',
+  component: AgentConsole,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof AgentConsole>;
+
+export const Basic: Story = {};

--- a/packages/shared-ui/src/AgentConsole.tsx
+++ b/packages/shared-ui/src/AgentConsole.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { Button } from './Button';
+
+export const AgentConsole = () => {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  const send = () => {
+    setMessages([...messages, input]);
+    setInput('');
+  };
+
+  return (
+    <div className="border rounded p-4 space-y-2 bg-gray-50">
+      <div className="h-40 overflow-y-auto border p-2 bg-white">
+        {messages.map((m, i) => (
+          <div key={i} className="mb-1">
+            {m}
+          </div>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="border flex-1 p-1"
+          placeholder="Type a message"
+        />
+        <Button onClick={send}>Send</Button>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared-ui/src/Button.stories.tsx
+++ b/packages/shared-ui/src/Button.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Atoms/Button',
+  component: Button,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = {
+  args: { children: 'Primary Button' }
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary', children: 'Secondary Button' }
+};

--- a/packages/shared-ui/src/Button.tsx
+++ b/packages/shared-ui/src/Button.tsx
@@ -1,0 +1,14 @@
+import { ButtonHTMLAttributes } from 'react';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export const Button = ({ variant = 'primary', className = '', ...props }: ButtonProps) => {
+  const base = 'px-4 py-2 rounded font-semibold';
+  const variants: Record<string, string> = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700',
+    secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300'
+  };
+  return <button className={`${base} ${variants[variant]} ${className}`} {...props} />;
+};

--- a/packages/shared-ui/src/Card.stories.tsx
+++ b/packages/shared-ui/src/Card.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card } from './Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Molecules/Card',
+  component: Card,
+  tags: ['autodocs'],
+};
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Basic: Story = {
+  args: {
+    title: 'Example Card',
+    children: 'Card content here'
+  }
+};

--- a/packages/shared-ui/src/Card.tsx
+++ b/packages/shared-ui/src/Card.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+export interface CardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export const Card = ({ title, children }: CardProps) => (
+  <div className="border rounded shadow p-4 bg-white">
+    <h3 className="font-bold mb-2">{title}</h3>
+    <div>{children}</div>
+  </div>
+);

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from './Button';
+export * from './Card';
+export * from './AgentConsole';

--- a/packages/shared-ui/tsconfig.json
+++ b/packages/shared-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/nextjs';
+
+const config: StorybookConfig = {
+  stories: ['../packages/shared-ui/**/*.stories.@(ts|tsx|js|jsx|mdx)'],
+  addons: [
+    '@storybook/addon-a11y',
+    '@storybook/addon-docs',
+    '@storybook/addon-controls'
+  ],
+  framework: {
+    name: '@storybook/nextjs',
+    options: {}
+  },
+  docs: { autodocs: true }
+};
+export default config;

--- a/storybook/preview.ts
+++ b/storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from '@storybook/react';
+import '../apps/frontend/app/globals.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on.*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/tests/visual/README.md
+++ b/tests/visual/README.md
@@ -1,0 +1,1 @@
+Baseline screenshots for Lost Pixel are stored here.


### PR DESCRIPTION
## Summary
- add shared-ui package with basic components and stories
- configure Storybook in new `/storybook` folder
- add Lost Pixel visual regression configuration
- add DesignOps GitHub Actions workflow
- document the new DesignOps setup

## Testing
- `pnpm lint` *(fails: nx not found)*
- `pnpm build` *(fails: nx not found)*
- `pnpm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879d5234cac832da11e2def56a19f8e