### PR TITLE
Add architecture docs and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,76 @@
 # Enterprise Monorepo
 
-This repository provides a boilerplate for a scalable AI‑native application platform. It uses an **Nx workspace** to manage polyglot microservices and shared packages.
+This repository provides a boilerplate for a scalable AI‑native application platform. It uses an **Nx workspace** to manage polyglot microservices and shared packages. See [architecture.md](architecture.md) for an overview of the data and control flow.
 
-## Folder Overview
+## Repository Structure
 
+### Applications
 - **apps/frontend** – Next.js App Router with Tailwind CSS, ShadCN UI and DaisyUI.
 - **apps/mobile** – Flutter project with PWA support generated via PWABuilder.
 - **apps/nest-core-api** – Nest.js API running on the Bun runtime and using Prisma ORM.
 - **apps/actix-core-api** – Rust microservice built with Actix Web.
 - **apps/gin-analytics-api** – Go service using the Gin framework for analytics features.
 - **apps/fastapi-report-engine** – FastAPI based reporting engine with Prisma client.
-- **genai-agents** – LangChain, CrewAI and AutoGen examples for multi‑agent orchestration.
+- **apps/docs** – Astro site containing developer and product documentation.
+
+### Agents and Control Plane
+- **genai-agents** – LangChain, CrewAI, AutoGen and other agent implementations.
+- **a2a-protocol** – utilities for agent‑to‑agent messaging.
+- **mcp-controller** – dispatches `AgentTask` objects to multiple agents and aggregates the results.
+
+### Data and Integrations
 - **vector-stores** – MongoDB Atlas and S3 clients for managing vector embeddings.
-- **data-platform** – dbt models, Glue Catalog/Athena queries, ClickHouse schemas and dashboards.
 - **sap-integration** – OData helpers and SAP BTP Destination configurations.
-- **packages** – Shared libraries such as auth-lib, utilities and the Prisma client.
+- **data-platform** – dbt models, Glue Catalog/Athena queries, ClickHouse schemas and dashboards.
+
+### Shared Packages
+- **packages/prisma-client** – generated Prisma client library.
+- **packages/realtime** – Fluid Framework helpers backed by Redis.
+- **packages/shared-ui** – React component library used by the frontend and docs.
+- **packages/utils** – general utilities shared across services.
+
+### Infrastructure and Tests
 - **infra** – Terraform modules, Dockerfiles, Kubernetes manifests and observability tooling.
-- **tests** – Playwright end‑to‑end test suite.
+- **tests** – Playwright end‑to‑end and visual test suite.
+- **storybook** – configuration for UI component development.
 
 Each service is intentionally minimal. Extend the modules as needed for your organisation.
+
+## Agents
+
+The `genai-agents` folder contains orchestrators used by the control plane:
+
+- **LangChainBedrockAgent** – wraps a LangChain agent running on AWS Bedrock.
+- **CrewAgent** – breaks down tasks by role using CrewAI.
+- **AutoGenOrchestrator** – multi‑agent dialogue orchestrated with AutoGen.
+- **LlamaIndexAgent** – retrieval‑augmented generation via LlamaIndex.
+- **LlamaGraphAgent** – knowledge graph querying powered by LlamaGraph.
+- **StrandsRoutingAgent** – decision making using Strands Agents.
+- **LangChainRouter** – routes tasks with Promptflow templates and Semantic Kernel.
+- **RedisStateStore** – persists agent state, chat context and collaborative docs.
+
+The `MultiAgentController` in `mcp-controller` dispatches a task to any combination of these agents.
+
+## Local Development
+
+1. Install Node.js 20+ and run `corepack enable` to activate pnpm.
+2. Install dependencies: `pnpm install`.
+3. Start all apps for development: `pnpm dev`.
+4. For the documentation site: `cd apps/docs && pnpm dev`.
+5. Python agents require `pip install -r genai-agents/requirements.txt`.
+
+## Cloud Deployment
+
+1. Provision infrastructure using the Terraform modules in `infra/`.
+2. Build container images from each application's Dockerfile and push them to your registry.
+3. Deploy the images to Kubernetes (manifests are provided in `infra/`).
+4. Configure environment variables for SAP access, vector stores and Redis as described in the respective READMEs.
+5. Run `dbt` and apply the dashboards under `data-platform` to set up analytics.
+
+## CI/CD
+
+- **ci.yml** – installs dependencies, lints, builds, and runs Playwright tests on pushes and pull requests. Successful runs on `main` trigger deployment.
+- **designops.yml** – builds Storybook and executes Lost Pixel visual regression tests when UI packages change.
 
 ## Real-time Collaboration
 
@@ -26,8 +78,4 @@ Each service is intentionally minimal. Extend the modules as needed for your org
 - The `@enterprise/realtime` package uses Fluid Framework to sync data in real time across the Next.js frontend and Flutter mobile app.
 - Example usage is provided as a shared task list where updates are stored in Redis along with agent state, chat context and collaborative docs.
 
-## DesignOps
-
-- Storybook renders UI components from `packages/shared-ui` with accessibility checks and docs.
-- Lost Pixel runs visual regression tests on Storybook to catch unintended UI changes.
-- GitHub Actions builds Storybook and executes Lost Pixel on pull requests targeting `main` or `release/*`.
+Refer to [architecture.md](architecture.md) for the full platform diagram.

--- a/architecture.md
+++ b/architecture.md
@@ -1,0 +1,57 @@
+# Architecture
+
+This document illustrates the high level architecture of the Enterprise platform and how the different agents interact with each other, with SAP and with the vector stores.
+
+## Components
+
+- **User Interfaces** – Next.js frontend and Flutter mobile app.
+- **Microservices** – REST/HTTP APIs implemented in NestJS, FastAPI, Actix and Gin.
+- **MultiAgentController** – dispatches tasks to GenAI agents.
+- **Agents** – wrappers around LLM frameworks (LangChain, AutoGen, CrewAI, LlamaIndex, etc.).
+- **SAP Integration** – utilities to call SAP systems via BTP Destination Service.
+- **Vector Stores** – MongoDB Atlas Vector Search and S3 for embeddings.
+- **Redis** – coordination and chat context persistence.
+- **Data Platform** – dbt models, Athena/Glue configuration and ClickHouse for analytics.
+
+## Data and Control Flow
+
+```mermaid
+graph TD
+    subgraph UI
+        A[Next.js Frontend] -- HTTP --> B(API Gateway)
+        C[Flutter App] -- HTTP --> B
+    end
+    subgraph Services
+        B -- REST --> D[Microservices]
+        D -- dispatch --> E[MultiAgentController]
+    end
+    subgraph Agents
+        E -- AgentTask --> F(LangChain/Bedrock)
+        E -- AgentTask --> G(CrewAI)
+        E -- AgentTask --> H(AutoGen)
+        E -- AgentTask --> I(LlamaIndex)
+        E -- AgentTask --> J(LlamaGraph)
+    end
+    F -- query --> X[LLM]
+    G -- query --> X
+    H -- query --> X
+    I -- vector search --> M[Vector Store]
+    J -- graph query --> M
+    E -- state --> R[Redis]
+    E -- SAP --> S[(SAP OData)]
+    R -- logs --> P[Data Platform]
+    D -- metrics --> P
+```
+
+1. Users interact with the Next.js or Flutter applications.
+2. Requests are routed through the microservices layer which then uses the `MultiAgentController` to run tasks across the configured agents.
+3. Agents call LLM providers (e.g. AWS Bedrock or OpenAI), query SAP systems and retrieve embeddings from the vector stores. They persist state and chat context in Redis.
+4. Usage data and logs feed into the data platform for analytics and dashboards.
+
+## Deployment Overview
+
+- Infrastructure resources (Redis, Bedrock, MongoDB Atlas, SAP BTP connectors) are provisioned via Terraform modules in `infra/`.
+- Each app has a Dockerfile for containerized deployment on Kubernetes or any container platform.
+- CI/CD pipelines build and test the workspace and deploy to the target environment when changes land on `main`.
+
+Refer to [README.md](README.md) for setup instructions.


### PR DESCRIPTION
## Summary
- document folder layout, agents, and workflows in README
- add architecture overview with data/control flow diagram

## Testing
- `pnpm lint` *(fails: nx not found)*
- `pnpm test` *(fails: nx not found)*


------
https://chatgpt.com/codex/tasks/task_e_6879d6a3ea80832d939d58d950dcf95b